### PR TITLE
Set autoscroll on new termitary-created terminals

### DIFF
--- a/lua/termitary.lua
+++ b/lua/termitary.lua
@@ -21,6 +21,7 @@ end
 -- Open a new terminal buffer and activate it
 M.new = function()
   vim.api.nvim_command('terminal')
+  vim.api.nvim_feedkeys('G', 't', false)
   return M.activate()
 end
 


### PR DESCRIPTION
This change sends a `G` to the terminal buffer (as mentioned [here](https://github.com/neovim/neovim/issues/2636)) to activate automatic scrolling when the output reaches the bottom of the window:

1. `:Termitary new`
2. `:Termitary type od -c /dev/random` (or anything else that generates a lot of output)